### PR TITLE
Add PublishTelemetryAvnetIoT custom recipe

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "GenX_Generated/AzureSphereDevX"]
 	path = GenX_Generated/AzureSphereDevX
-	url = https://github.com/bawilless/AzureSphereDevX.git
+	url = https://github.com/gloveboxes/AzureSphereDevX.git
 [submodule "GenX_Generated/Drivers"]
 	path = GenX_Generated/Drivers
 	url = https://github.com/gloveboxes/AzureSphereDrivers.git

--- a/Generator/app_model.json
+++ b/Generator/app_model.json
@@ -31,10 +31,9 @@
     ],
     "device_twins": [
       {
-        "name": "SetDesiredTemperature",
+        "name": "ReportTemperature",
         "enabled": false,
         "properties": {
-          "cloud2device": true,
           "type": "float"
         }
       },
@@ -47,32 +46,25 @@
         }
       },
       {
-        "name": "ReportTemperature",
+        "name": "SetDesiredTemperature",
         "enabled": false,
         "properties": {
+          "cloud2device": true,
           "type": "float"
         }
       }
     ],
     "direct_methods": [
       {
-        "name": "LightOn",
+        "name": "LightOff",
         "enabled": false
       },
       {
-        "name": "LightOff",
+        "name": "LightOn",
         "enabled": false
       }
     ],
     "timers": [
-      {
-        "name": "MeasureTemperature",
-        "enabled": false,
-        "properties": {
-          "period": "{ 5, 0 }",
-          "type": "periodic"
-        }
-      },
       {
         "name": "MeasureCarbonMonoxide",
         "enabled": false,
@@ -80,6 +72,14 @@
           "type": "oneshot",
           "autostart": true,
           "period": "{ 5, 0 }"
+        }
+      },
+      {
+        "name": "MeasureTemperature",
+        "enabled": false,
+        "properties": {
+          "period": "{ 5, 0 }",
+          "type": "periodic"
         }
       },
       {
@@ -132,8 +132,23 @@
         "enabled": false
       },
       {
+        "name": "DirectMethodLightControl",
+        "description": "Turn light/relay on and off from a direct method",
+        "enabled": false
+      },   
+      {
+        "name": "PublishTelemetryAvnetIoT",
+        "description": "Publish telemetry to Avnet's IoT Connect Platform",
+        "enabled": false
+      },
+      {
         "name": "PublishTelemetryAzureIoT",
         "description": "Publish telemetry to Azure IoT",
+        "enabled": false
+      },
+      {
+        "name": "ReportStartup",
+        "description": "Report start utc time and software version",
         "enabled": false
       },
       {
@@ -143,18 +158,8 @@
         "enabled": false
       },
       {
-        "name": "DirectMethodLightControl",
-        "description": "Turn light/relay on and off from a direct method",
-        "enabled": false
-      },
-      {
         "name": "Watchdog",
         "description": "Watchdog on a 30 second refresh cadence",
-        "enabled": false
-      },
-      {
-        "name": "ReportStartup",
-        "description": "Report start utc time and software version",
         "enabled": false
       }
     ]

--- a/Generator/custom_bindings/PublishTelemetryAvnetIoT/PublishTelemetryAvnetIoT.handler
+++ b/Generator/custom_bindings/PublishTelemetryAvnetIoT/PublishTelemetryAvnetIoT.handler
@@ -1,0 +1,64 @@
+/// <summary>
+/// Publish environment sensor telemetry to Avnet's IoT Connect Platform
+/// </summary>
+/// <param name="eventLoopTimer"></param>
+static void {name}_gx_handler(EventLoopTimer *eventLoopTimer) {{
+
+    if (ConsumeEventLoopTimerEvent(eventLoopTimer) != 0) {{
+        dx_terminate(DX_ExitCode_ConsumeEventLoopTimeEvent);
+        return;
+    }}
+
+    float temperature = 30.0f;
+    float humidity = 60.0f;
+    float pressure = 1010.0f;
+
+{device_twin_variables}
+    if (dx_isAvnetConnected()) {{
+
+		// Example #1: Pass in telemetry by <type, key, value> triples
+
+        // Serialize telemetry as JSON
+        bool serialization_result = dx_avnetJsonSerialize(gx_{name}Buffer, sizeof(gx_{name}Buffer), 3, 
+            DX_JSON_FLOAT, "Temperature", temperature, 
+            DX_JSON_FLOAT, "Humidity", humidity,
+            DX_JSON_FLOAT, "Pressure", pressure);
+
+        if (serialization_result) {{
+            Log_Debug("%s\n", gx_{name}Buffer);
+            
+            dx_azurePublish(gx_{name}Buffer, strlen(gx_{name}Buffer), gx_{name}MessageProperties, 
+                            NELEMS(gx_{name}MessageProperties), &gx_{name}ContentProperties);
+        
+        }} else {{
+            Log_Debug("gx_{name}Buffer to small to serialize JSON\n");
+        }}
+
+		// Example #2: Build JSON telemetry string, then add IoTConnect wrapper before sending it to the
+		// IoTHub
+
+		// Create a buffer and format specifier for the JSON document to send
+		char json_buffer[DX_AVNET_IOT_CONNECT_JSON_BUFFER_SIZE] = {{0}};
+	    static const char json_string_format[] =
+        "{{\"Temperature2\":%.1f,\"Humidity2\":%.1f,\"Pressure2\":%.1f}}";
+
+		// Create the JSON document
+        snprintf(json_buffer, DX_AVNET_IOT_CONNECT_JSON_BUFFER_SIZE, json_string_format, 
+				temperature, humidity, pressure);
+
+		// Call the routine that will wrap the JSON document with the IoT Connect specific data
+		serialization_result = dx_avnetJsonSerializePayload(json_buffer, gx_{name}Buffer, sizeof(gx_{name}Buffer));
+
+		// Send the telemetry
+        if (serialization_result) {{
+            Log_Debug("%s\n", gx_{name}Buffer);
+            
+            dx_azurePublish(gx_{name}Buffer, strlen(gx_{name}Buffer), gx_{name}MessageProperties, 
+                            NELEMS(gx_{name}MessageProperties), &gx_{name}ContentProperties);
+        
+        }} else {{
+            Log_Debug("gx_{name}Buffer to small to serialize JSON\n");
+        }}
+
+{device_twins_updates}    }}
+}}

--- a/Generator/custom_bindings/PublishTelemetryAvnetIoT/PublishTelemetryAvnetIoT.include
+++ b/Generator/custom_bindings/PublishTelemetryAvnetIoT/PublishTelemetryAvnetIoT.include
@@ -1,0 +1,21 @@
+#pragma once
+#include "dx_azure_iot.h"
+#include "dx_avnet_iot_connect.h"
+
+/****************************************************************************************
+ * Telemetry message templates and property sets
+ ****************************************************************************************/
+#define GX_AZURE_IOT false
+#define GX_AVNET_IOT true
+
+// Number of bytes to allocate for the JSON telemetry message for IoT Hub/Central
+#define {name}_JSON_MESSAGE_LENGTH 128 + DX_AVNET_IOT_CONNECT_METADATA
+
+static char gx_{name}Buffer[{name}_JSON_MESSAGE_LENGTH] = {{0}};
+
+static DX_MESSAGE_PROPERTY *gx_{name}MessageProperties[] = {{
+    &(DX_MESSAGE_PROPERTY){{.key = "appid", .value = "hvac"}},
+    &(DX_MESSAGE_PROPERTY){{.key = "type", .value = "telemetry"}},
+    &(DX_MESSAGE_PROPERTY){{.key = "schema", .value = "1"}}}};
+
+static DX_MESSAGE_CONTENT_PROPERTIES gx_{name}ContentProperties = {{.contentEncoding = "utf-8", .contentType = "application/json"}};

--- a/Generator/custom_bindings/PublishTelemetryAvnetIoT/PublishTelemetryAvnetIoT.timer.binding.json
+++ b/Generator/custom_bindings/PublishTelemetryAvnetIoT/PublishTelemetryAvnetIoT.timer.binding.json
@@ -1,0 +1,6 @@
+{
+    "properties": {
+        "period": "{ 5, 0 }",
+        "type": "periodic"
+    }
+}

--- a/Generator/templates/declarations.template
+++ b/Generator/templates/declarations.template
@@ -23,7 +23,7 @@ extern const char NETWORK_INTERFACE[];
 
 #define ONE_MS 1000000		// used to simplify timer defn.
 #define Log_Debug(f_, ...) dx_Log_Debug((f_), ##__VA_ARGS__)
-static char Log_Debug_buffer[128];
+static char Log_Debug_buffer[256];
 
 
 /****************************************************************************************

--- a/Generator/templates/declarations.template
+++ b/Generator/templates/declarations.template
@@ -3,6 +3,7 @@
 #include "hw/azure_sphere_learning_path.h" // Hardware definition
 
 #include "dx_azure_iot.h"
+#include "dx_avnet_iot_connect.h"
 #include "dx_config.h"
 #include "dx_exit_codes.h"
 #include "dx_gpio.h"

--- a/Generator/templates/declarations_footer.template
+++ b/Generator/templates/declarations_footer.template
@@ -7,7 +7,9 @@
 static void gx_initPeripheralAndHandlers(void)
 {
 
-#ifdef GX_AZURE_IOT
+#ifdef GX_AVNET_IOT
+    dx_avnetConnect(&dx_config, NETWORK_INTERFACE);
+#elif GX_AZURE_IOT
     dx_azureConnect(&dx_config, NETWORK_INTERFACE, PNP_MODEL_ID);
 #else
     if (NELEMS(device_twin_bindings) > 0 || NELEMS(direct_method_bindings) > 0) {


### PR DESCRIPTION
Add new recipe to send Avnet IoTConnect Telemetry

Note these changes should be pulled in along with the devX/Avnet branch

- add GX_AVNET_IOT compile time flag and logic to call dx_avnetConnect() when enabled
- Log_Debug_buffer[] size was increased to account for a larger debug buffer when displaying IoTConnect telemetry.  Telemetry messages output to debug were truncated with the original buffer size.